### PR TITLE
   Add automatic detection for macOS Blender and Blender Python paths

### DIFF
--- a/sceneprogexec/exec.py
+++ b/sceneprogexec/exec.py
@@ -16,6 +16,27 @@ class SceneProgExecutor:
         blender_python = os.getenv("BLENDER_PYTHON")
 
         if blender_path is None or blender_python is None:
+            from .path_auto_detection import find_blender_path, find_blender_python_path
+            
+            print("The environment variable BLENDER_PATH or BLENDER_PYTHON is not set, attempting automatic detection...")
+            detected_blender_path = find_blender_path()
+            
+            if detected_blender_path:
+                detected_python_path = find_blender_python_path(detected_blender_path)
+                
+                if detected_python_path:
+                    print(f"Automatically detected Blender path: {detected_blender_path}")
+                    print(f"Automatically detected Python path: {detected_python_path}")
+                    
+                    # Set environment variables for subsequent use
+                    os.environ["BLENDER_PATH"] = detected_blender_path
+                    os.environ["BLENDER_PYTHON"] = detected_python_path
+                    
+                    # Update the variables of the current instance
+                    blender_path = detected_blender_path
+                    blender_python = detected_python_path
+
+        if blender_path is None or blender_python is None:
             msg = """
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 BLENDER_PATH and BLENDER_PYTHON environment variables must be set.

--- a/sceneprogexec/path_auto_detection.py
+++ b/sceneprogexec/path_auto_detection.py
@@ -1,0 +1,58 @@
+import os
+import platform
+
+def find_blender_path():
+    system = platform.system()
+    if system == "Darwin":
+        print("Running on macOS")
+        if os.path.exists("/Applications/Blender.app/Contents/MacOS/Blender"):
+            return "/Applications/Blender.app/Contents/MacOS/Blender"
+    else:
+        print("Blender not found")
+        return None
+    # TODO: Add Linux and Windows paths
+    # elif system == "Linux":
+    # elif system == "Windows":
+        
+
+
+def find_blender_python_path(blender_path):
+    system = platform.system()
+    if not blender_path:
+        return None
+    
+    if system == "Darwin":  # macOS
+        # /Applications/Blender.app/Contents/MacOS/Blender 
+        base_dir = os.path.dirname(os.path.dirname(blender_path))
+
+        # different versions of blender have different versions of python in Resources
+        resources_dir = os.path.join(base_dir, "Resources")
+
+        # We only care the newest version of python in Resources now
+        # export BLENDER_PYTHON=/Applications/Blender.app/Contents/Resources/4.3/python/bin/python3.11
+        # TODO: Compatible with different versions of Blender
+        if os.path.exists(os.path.join(resources_dir, "4.3", "python", "bin", "python3.11")):
+            python_path = os.path.join(resources_dir, "4.3", "python", "bin", "python3.11")
+            return python_path
+        else:
+            print("Blender Python not found")
+            return None
+        
+    # TODO: Add Linux and Windows paths
+    # elif system == "Linux":
+    # elif system == "Windows":
+
+if __name__ == "__main__":
+    if not os.environ.get("BLENDER_PATH") or not os.environ.get("BLENDER_PYTHON"):
+        # Try to auto-detect paths
+        detected_blender_path = find_blender_path()
+        if detected_blender_path:
+            detected_python_path = find_blender_python_path(detected_blender_path)
+            if detected_python_path:
+                # Set environment variables for current process
+                os.environ["BLENDER_PATH"] = detected_blender_path
+                os.environ["BLENDER_PYTHON"] = detected_python_path
+                print(f"Auto-detected Blender path: {detected_blender_path}")
+                print(f"Auto-detected Python path: {detected_python_path}")
+
+


### PR DESCRIPTION
   ## Description
   This PR adds automatic detection functionality for Blender and Blender Python paths on macOS systems. When environment variables are not set, the system will try to locate Blender and its Python interpreter automatically.

   ## Changes
   - Added `path_auto_detection.py` module with functions to detect Blender paths
   - Updated `exec.py` to use automatic detection when environment variables are not set
   - Currently only supports macOS, with TODOs in place for Windows and Linux

   ## Notes
   - The implementation focuses on the latest Blender version (4.3)
   - Linux and Windows implementations are left as TODOs for future work